### PR TITLE
Removes Check Rule 39 mail service from the list

### DIFF
--- a/routes/feedbackAndSupportRouter.js
+++ b/routes/feedbackAndSupportRouter.js
@@ -41,10 +41,4 @@ router.get('/prepare-a-case', (req, res) => res.render('services/prepareACase', 
 
 router.get('/workload-measurement-tool', (req, res) => res.render('services/workloadMeasurementTool', { backLinkUrl }))
 
-router.get('/check-rule39-mail', (req, res) =>
-  res.redirect(
-    `${config.urls.checkRule39Mail}scan-barcode/contact-helpdesk?pageId=prison-services-feedback-and-support`
-  )
-)
-
 module.exports = router

--- a/views/feedbackAndSupport.njk
+++ b/views/feedbackAndSupport.njk
@@ -50,10 +50,6 @@
           text: "Check my diary"
         },
         {
-          value: "check-rule39-mail",
-          text: "Check Rule 39 mail"
-        },
-        {
           value: "categorisation-tool",
           text: "Digital Categorisation Service"
         },


### PR DESCRIPTION
This PR removes the Check Rule 39 mail service from the list of supported services.  The existing link does not work and there is no equivalent. 